### PR TITLE
Fix yaml loading

### DIFF
--- a/lib/test_data/config.rb
+++ b/lib/test_data/config.rb
@@ -1,3 +1,5 @@
+require_relative "./yaml_loader"
+
 module TestData
   def self.config(pwd: Rails.root, &blk)
     @configuration ||= Configuration.new(pwd: pwd)
@@ -95,7 +97,7 @@ module TestData
     end
 
     def database_yaml
-      YAML.load_file(database_yaml_full_path)
+      YAMLLoader.load_file(database_yaml_full_path)
     end
 
     def database_name

--- a/lib/test_data/configurators/cable_yaml.rb
+++ b/lib/test_data/configurators/cable_yaml.rb
@@ -1,3 +1,5 @@
+require_relative "../yaml_loader"
+
 module TestData
   module Configurators
     class CableYaml
@@ -8,7 +10,7 @@ module TestData
 
       def verify
         if !File.exist?(@config.cable_yaml_full_path) ||
-            YAML.load_file(@config.cable_yaml_full_path).key?("test_data")
+            YAMLLoader.load_file(@config.cable_yaml_full_path).key?("test_data")
           ConfigurationVerification.new(looks_good?: true)
         else
           ConfigurationVerification.new(problems: [

--- a/lib/test_data/configurators/secrets_yaml.rb
+++ b/lib/test_data/configurators/secrets_yaml.rb
@@ -1,3 +1,5 @@
+require_relative "../yaml_loader"
+
 module TestData
   module Configurators
     class SecretsYaml
@@ -8,7 +10,7 @@ module TestData
 
       def verify
         if !File.exist?(@config.secrets_yaml_full_path) ||
-            YAML.load_file(@config.secrets_yaml_full_path).key?("test_data")
+            YAMLLoader.load_file(@config.secrets_yaml_full_path).key?("test_data")
           ConfigurationVerification.new(looks_good?: true)
         else
           ConfigurationVerification.new(problems: [

--- a/lib/test_data/dumps_database.rb
+++ b/lib/test_data/dumps_database.rb
@@ -80,7 +80,7 @@ module TestData
 
     def log_size_info_and_warnings(before_size:, after_size:)
       percent_change = percent_change(before_size, after_size)
-      TestData.log.info "  Size: #{to_size(after_size)}#{" (#{percent_change}% #{before_size > after_size ? "decrease" : "increase"})" if percent_change}"
+      TestData.log.info "  Size: #{to_size(after_size)}#{" (#{percent_change}% #{(before_size > after_size) ? "decrease" : "increase"})" if percent_change}"
       if after_size > 5242880
         TestData.log.warn "  WARNING: file size exceeds 5MB. Be sure to only persist what data you need to sufficiently test your application"
       end

--- a/lib/test_data/wrap/webpacker_config.rb
+++ b/lib/test_data/wrap/webpacker_config.rb
@@ -1,3 +1,5 @@
+require_relative "../yaml_loader"
+
 module TestData
   module Wrap
     class WebpackerConfig
@@ -34,7 +36,7 @@ module TestData
       private
 
       def load_yaml(path)
-        YAML.load_file(path)
+        YAMLLoader.load_file(path)
       rescue
       end
     end

--- a/lib/test_data/yaml_loader.rb
+++ b/lib/test_data/yaml_loader.rb
@@ -1,0 +1,11 @@
+module TestData
+  module YAMLLoader
+    def self.load_file(path)
+      begin
+        YAML.load_file(path, aliases: true)
+      rescue ArgumentError
+        YAML.load_file(path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Reference: https://stackoverflow.com/a/71192990

Calling `YAML.load_file` on the Rails `database.yaml` file (which has a
`&default` alias in it) breaks given recent changes in Psych v4 in Ruby
3.1.

This adjustment follows [a patch that can be found in Rails](https://github.com/rails/rails/commit/179d0a1f474ada02e0030ac3bd062fc653765dbe), but extracts into a module, given `YAML.load_file` is being called in multiple places.

Regarding testing - I wasn't sure if it would be better to just have this project's test suite run against multiple versions of Ruby, or if you'd prefer me to try to use mocks/etc to test this functionality.