### PR TITLE
Adds option to YAML load of database.yml so that Psych doesn't complain.

### DIFF
--- a/lib/test_data/config.rb
+++ b/lib/test_data/config.rb
@@ -97,7 +97,7 @@ module TestData
     end
 
     def database_yaml
-      YAMLLoader.load_file(database_yaml_full_path)
+      YAMLLoader.load_file(database_yaml_full_path, aliases: true)
     end
 
     def database_name

--- a/lib/test_data/determines_databases_associated_dump_time.rb
+++ b/lib/test_data/determines_databases_associated_dump_time.rb
@@ -1,7 +1,8 @@
 module TestData
   class DeterminesDatabasesAssociatedDumpTime
     def call
-      if (last_dumped_at = ActiveRecord::InternalMetadata.find_by(key: "test_data:last_dumped_at")&.value)
+      internal_metadata = ActiveRecord::InternalMetadata.new(ActiveRecord::Base.connection)
+      if (last_dumped_at = internal_metadata["test_data:last_dumped_at"])
         Time.parse(last_dumped_at)
       end
     rescue ActiveRecord::StatementInvalid


### PR DESCRIPTION
I ran install against a Rails 7.1 app and got this stack trace:

```sh
❯ bin/rake test_data:install
   identical  config/environments/test_data.rb
   identical  config/initializers/test_data.rb
rake aborted!
Psych::AliasesNotEnabled: Alias parsing was not enabled. To enable it, pass `aliases: true` to `Psych::load` or `Psych::safe_load`. (Psych::AliasesNotEnabled)
/Users/dwfrank/workspace/meals/vendor/bundle/ruby/3.2.0/gems/psych-5.1.2/lib/psych/visitors/to_ruby.rb:432:in `visit_Psych_Nodes_Alias'
/Users/dwfrank/workspace/meals/vendor/bundle/ruby/3.2.0/gems/psych-5.1.2/lib/psych/visitors/visitor.rb:30:in `visit'
/Users/dwfrank/workspace/meals/vendor/bundle/ruby/3.2.0/gems/psych-5.1.2/lib/psych/visitors/visitor.rb:6:in `accept'
/Users/dwfrank/workspace/meals/vendor/bundle/ruby/3.2.0/gems/psych-5.1.2/lib/psych/visitors/to_ruby.rb:35:in `accept'
/Users/dwfrank/workspace/meals/vendor/bundle/ruby/3.2.0/gems/psych-5.1.2/lib/psych/visitors/to_ruby.rb:347:in `block in revive_hash'
/Users/dwfrank/workspace/meals/vendor/bundle/ruby/3.2.0/gems/psych-5.1.2/lib/psych/visitors/to_ruby.rb:345:in `each'
/Users/dwfrank/workspace/meals/vendor/bundle/ruby/3.2.0/gems/psych-5.1.2/lib/psych/visitors/to_ruby.rb:345:in `each_slice'
/Users/dwfrank/workspace/meals/vendor/bundle/ruby/3.2.0/gems/psych-5.1.2/lib/psych/visitors/to_ruby.rb:345:in `revive_hash'
/Users/dwfrank/workspace/meals/vendor/bundle/ruby/3.2.0/gems/psych-5.1.2/lib/psych/visitors/to_ruby.rb:169:in `visit_Psych_Nodes_Mapping'
/Users/dwfrank/workspace/meals/vendor/bundle/ruby/3.2.0/gems/psych-5.1.2/lib/psych/visitors/visitor.rb:30:in `visit'
/Users/dwfrank/workspace/meals/vendor/bundle/ruby/3.2.0/gems/psych-5.1.2/lib/psych/visitors/visitor.rb:6:in `accept'
/Users/dwfrank/workspace/meals/vendor/bundle/ruby/3.2.0/gems/psych-5.1.2/lib/psych/visitors/to_ruby.rb:35:in `accept'
/Users/dwfrank/workspace/meals/vendor/bundle/ruby/3.2.0/gems/psych-5.1.2/lib/psych/visitors/to_ruby.rb:347:in `block in revive_hash'
/Users/dwfrank/workspace/meals/vendor/bundle/ruby/3.2.0/gems/psych-5.1.2/lib/psych/visitors/to_ruby.rb:345:in `each'
/Users/dwfrank/workspace/meals/vendor/bundle/ruby/3.2.0/gems/psych-5.1.2/lib/psych/visitors/to_ruby.rb:345:in `each_slice'
/Users/dwfrank/workspace/meals/vendor/bundle/ruby/3.2.0/gems/psych-5.1.2/lib/psych/visitors/to_ruby.rb:345:in `revive_hash'
/Users/dwfrank/workspace/meals/vendor/bundle/ruby/3.2.0/gems/psych-5.1.2/lib/psych/visitors/to_ruby.rb:169:in `visit_Psych_Nodes_Mapping'
/Users/dwfrank/workspace/meals/vendor/bundle/ruby/3.2.0/gems/psych-5.1.2/lib/psych/visitors/visitor.rb:30:in `visit'
/Users/dwfrank/workspace/meals/vendor/bundle/ruby/3.2.0/gems/psych-5.1.2/lib/psych/visitors/visitor.rb:6:in `accept'
/Users/dwfrank/workspace/meals/vendor/bundle/ruby/3.2.0/gems/psych-5.1.2/lib/psych/visitors/to_ruby.rb:35:in `accept'
/Users/dwfrank/workspace/meals/vendor/bundle/ruby/3.2.0/gems/psych-5.1.2/lib/psych/visitors/to_ruby.rb:320:in `visit_Psych_Nodes_Document'
/Users/dwfrank/workspace/meals/vendor/bundle/ruby/3.2.0/gems/psych-5.1.2/lib/psych/visitors/visitor.rb:30:in `visit'
/Users/dwfrank/workspace/meals/vendor/bundle/ruby/3.2.0/gems/psych-5.1.2/lib/psych/visitors/visitor.rb:6:in `accept'
/Users/dwfrank/workspace/meals/vendor/bundle/ruby/3.2.0/gems/psych-5.1.2/lib/psych/visitors/to_ruby.rb:35:in `accept'
/Users/dwfrank/workspace/meals/vendor/bundle/ruby/3.2.0/gems/psych-5.1.2/lib/psych.rb:334:in `safe_load'
/Users/dwfrank/workspace/meals/vendor/bundle/ruby/3.2.0/gems/psych-5.1.2/lib/psych.rb:660:in `block in safe_load_file'
/Users/dwfrank/workspace/meals/vendor/bundle/ruby/3.2.0/gems/psych-5.1.2/lib/psych.rb:659:in `open'
/Users/dwfrank/workspace/meals/vendor/bundle/ruby/3.2.0/gems/psych-5.1.2/lib/psych.rb:659:in `safe_load_file'
/Users/dwfrank/workspace/meals/vendor/bundle/ruby/3.2.0/gems/test_data-0.3.2/lib/test_data/config.rb:98:in `database_yaml'
/Users/dwfrank/workspace/meals/vendor/bundle/ruby/3.2.0/gems/test_data-0.3.2/lib/test_data/configurators/database_yaml.rb:10:in `verify'
/Users/dwfrank/workspace/meals/vendor/bundle/ruby/3.2.0/gems/test_data-0.3.2/lib/generators/test_data/database_yaml_generator.rb:7:in `call'
/Users/dwfrank/workspace/meals/vendor/bundle/ruby/3.2.0/gems/test_data-0.3.2/lib/test_data/configurators/database_yaml.rb:20:in `configure'
/Users/dwfrank/workspace/meals/vendor/bundle/ruby/3.2.0/gems/test_data-0.3.2/lib/test_data/installs_configuration.rb:5:in `block in call'
/Users/dwfrank/workspace/meals/vendor/bundle/ruby/3.2.0/gems/test_data-0.3.2/lib/test_data/installs_configuration.rb:4:in `each'
/Users/dwfrank/workspace/meals/vendor/bundle/ruby/3.2.0/gems/test_data-0.3.2/lib/test_data/installs_configuration.rb:4:in `call'
/Users/dwfrank/workspace/meals/vendor/bundle/ruby/3.2.0/gems/test_data-0.3.2/lib/test_data/rake.rb:40:in `block in <main>'
Tasks: TOP => test_data:install => test_data:configure
(See full trace by running task with --trace)
```
I'm not sure why this wouldn't happen always, but FWIW, this is my database.yml

```yaml
# SQLite. Versions 3.8.0 and up are supported.
#   gem install sqlite3
#
#   Ensure the SQLite 3 gem is defined in your Gemfile
#   gem "sqlite3"
#
default: &default
  adapter: sqlite3
  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
  timeout: 5000

development:
  <<: *default
  database: db/development.sqlite3

# Warning: The database defined as "test" will be erased and
# re-generated from your development database when you run "rake".
# Do not set this db to the same as development or production.
test:
  <<: *default
  database: db/test.sqlite3

production:
  <<: *default
  database: db/production/production.sqlite3
```

This change to `config.rb` got what looks like the right lines are inserted into my `database.yml`


