### PR TITLE
Attempts to fix #9 

### DIFF
--- a/lib/test_data/determines_databases_associated_dump_time.rb
+++ b/lib/test_data/determines_databases_associated_dump_time.rb
@@ -1,7 +1,8 @@
 module TestData
   class DeterminesDatabasesAssociatedDumpTime
     def call
-      if (last_dumped_at = ActiveRecord::InternalMetadata.find_by(key: "test_data:last_dumped_at")&.value)
+      internal_metadata = ActiveRecord::InternalMetadata.new(ActiveRecord::Base.connection)
+      if (last_dumped_at = internal_metadata["test_data:last_dumped_at"])
         Time.parse(last_dumped_at)
       end
     rescue ActiveRecord::StatementInvalid


### PR DESCRIPTION
...by explicitly creating a new instance of InternalMetaData before checking.

I expect this won't work with Rails < 7.1. But this got me to the point where I could create and migrate my test_data DB.